### PR TITLE
Bump builder to golang:1.25-bookworm for BSC v1.7.7+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build bsc-geth in a stock Go builder container
-FROM golang:1.24-bookworm AS builder
+FROM golang:1.25-bookworm AS builder
 
 ARG BUILD_TAG=master
 


### PR DESCRIPTION
## Summary
- BSC v1.7.7's `go.mod` now requires `go >= 1.25.0`. The Dockerfile's builder stage is pinned to `golang:1.24-bookworm` with `GOTOOLCHAIN=local`, so building v1.7.7 (needed for the Pasteur hard fork, 2026-08-25 02:30 UTC) fails with:

  ```
  go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
  make: *** [Makefile:16: geth] Error 1
  ```
